### PR TITLE
Bump protocol version

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -30,13 +30,13 @@ static const int DATABASE_VERSION = 70509;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60015;
+static const int PROTOCOL_VERSION = 60016;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 60014;
+static const int MIN_PEER_PROTO_VERSION = 60016;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this
@@ -44,7 +44,7 @@ static const int CADDR_TIME_VERSION = 31402;
 
 // only request blocks from nodes outside this range of versions
 static const int NOBLKS_VERSION_START = 60002;
-static const int NOBLKS_VERSION_END = 60013;
+static const int NOBLKS_VERSION_END = 60015;
 
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;


### PR DESCRIPTION
Protocol, Min, and NOBLKS versions update to reject old (pre-fork) clients